### PR TITLE
Make serial.baudrate configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ optional arguments:
   --portname PORTNAME   Port name for example /dev/ttyUSB0
   --slaveaddress SLAVEADDRESS
                         Slave address 1-247
+  --baudrate BAUDRATE   Baudrate to communicate with controller (default is 115200)
 ```
 
 Example output

--- a/epevermodbus/command_line.py
+++ b/epevermodbus/command_line.py
@@ -11,9 +11,13 @@ def main():
     parser.add_argument(
         "--slaveaddress", help="Slave address 1-247", default=1, type=int
     )
+
+    parser.add_argument(
+        "--baudrate", help="Baudrate to communicate with controller (default is 115200)", default=115200, type=int
+    )
     args = parser.parse_args()
 
-    controller = EpeverChargeController(args.portname, args.slaveaddress)
+    controller = EpeverChargeController(args.portname, args.slaveaddress, args.baudrate)
 
     print("Real Time Data")
     print(f"Solar voltage: {controller.get_solar_voltage()}V")

--- a/epevermodbus/driver.py
+++ b/epevermodbus/driver.py
@@ -11,6 +11,7 @@ class EpeverChargeController(minimalmodbus.Instrument):
     Args:
         * portname (str): port name
         * slaveaddress (int): slave address in the range 1 to 247
+        * baudrate (int): baudrate to communicate with controller (default is 115200)
 
     """
 
@@ -29,9 +30,9 @@ class EpeverChargeController(minimalmodbus.Instrument):
         "discharging_limit_voltage"
     ]
 
-    def __init__(self, portname, slaveaddress):
+    def __init__(self, portname, slaveaddress, baudrate=115200):
         minimalmodbus.Instrument.__init__(self, portname, slaveaddress)
-        self.serial.baudrate = 115200
+        self.serial.baudrate = baudrate
         self.serial.bytesize = 8
         self.serial.parity = serial.PARITY_NONE
         self.serial.stopbits = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="epevermodbus",
-    version="0.0.14",
+    version="0.0.15",
     description="",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
This PR makes serial.baudrate a configurable parameter both via the python class and via the command line in a backwards compatible way.

## Reasoning
Some versions of the firmware for the Tracer AN series of charge controller have a different baudrate to the "standard" of 115200. The most common that I have encountered is 9600.  
While in theory this can be fixed by reconfiguring the charge controller, in practice this is not always an option.  
This PR allows users to configure the baudrate to use, while still maintaining the default value of 115200 to allow for backwards-compatibility.