### PR TITLE
Add support to read and write more values via library and command line

### DIFF
--- a/epevermodbus/command_line.py
+++ b/epevermodbus/command_line.py
@@ -18,6 +18,11 @@ def main():
     )
 
     parser.add_argument("--set-time", help="Set the RTC of the MPPT and exit", action="store_true")
+    parser.add_argument(
+        "--set-battery-temp-comp-coeff",
+        help="Sets the batteries temperature compensation coefficient. Coefficient is in mV/°C/Cell without the sign",
+        type=float,
+    )
     args = parser.parse_args()
 
     controller = EpeverChargeController(args.portname, args.slaveaddress, args.baudrate)
@@ -26,6 +31,22 @@ def main():
         print(f"Old RTC value: {controller.get_rtc()}")
         controller.set_rtc(datetime.datetime.now())
         print(f"New RTC value: {controller.get_rtc()}")
+
+    if args.set_battery_temp_comp_coeff:
+        print(
+            "Old Temperature compensation coefficient: "
+            f"{controller.get_temperature_compensation_coefficient()}mV/°C/Cell"
+        )
+        controller.set_temperature_compensation_coefficient(args.set_battery_temp_comp_coeff)
+        print(
+            "New Temperature compensation coefficient: "
+            f"{controller.get_temperature_compensation_coefficient()}mV/°C/Cell"
+        )
+
+    if any([
+        args.set_time,
+        args.set_battery_temp_comp_coeff,
+    ]):
         exit(0)
 
     print("Real Time Data")

--- a/epevermodbus/command_line.py
+++ b/epevermodbus/command_line.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 
 from epevermodbus.driver import EpeverChargeController
 
@@ -15,9 +16,17 @@ def main():
     parser.add_argument(
         "--baudrate", help="Baudrate to communicate with controller (default is 115200)", default=115200, type=int
     )
+
+    parser.add_argument("--set-time", help="Set the RTC of the MPPT and exit", action="store_true")
     args = parser.parse_args()
 
     controller = EpeverChargeController(args.portname, args.slaveaddress, args.baudrate)
+
+    if args.set_time:
+        print(f"Old RTC value: {controller.get_rtc()}")
+        controller.set_rtc(datetime.datetime.now())
+        print(f"New RTC value: {controller.get_rtc()}")
+        exit(0)
 
     print("Real Time Data")
     print(f"Solar voltage: {controller.get_solar_voltage()}V")
@@ -53,6 +62,7 @@ def main():
     )
     print(
         f"Device over temperature: {controller.is_device_over_temperature()}")
+    print(f"Current device time: {controller.get_rtc()}")
     print("\n")
 
     print("Battery Parameters:")

--- a/epevermodbus/command_line.py
+++ b/epevermodbus/command_line.py
@@ -18,6 +18,7 @@ def main():
     )
 
     parser.add_argument("--set-time", help="Set the RTC of the MPPT and exit", action="store_true")
+    parser.add_argument("--set-battery-capacity", help="Set the battery capacity in Ah an exit", type=int)
     parser.add_argument(
         "--set-battery-temp-comp-coeff",
         help="Sets the batteries temperature compensation coefficient. Coefficient is in mV/°C/Cell without the sign",
@@ -32,6 +33,11 @@ def main():
         controller.set_rtc(datetime.datetime.now())
         print(f"New RTC value: {controller.get_rtc()}")
 
+    if args.set_battery_capacity:
+        print(f"Old capacity: {controller.get_battery_capacity()}AH")
+        controller.set_battery_capacity(args.set_battery_capacity)
+        print(f"New capacity: {controller.get_battery_capacity()}AH")
+
     if args.set_battery_temp_comp_coeff:
         print(
             "Old Temperature compensation coefficient: "
@@ -45,6 +51,7 @@ def main():
 
     if any([
         args.set_time,
+        args.set_battery_capacity,
         args.set_battery_temp_comp_coeff,
     ]):
         exit(0)

--- a/epevermodbus/command_line.py
+++ b/epevermodbus/command_line.py
@@ -74,8 +74,8 @@ def main():
     print(f"Battery type: {controller.get_battery_type()}")
     print(f"Battery capacity: {controller.get_battery_capacity()}AH")
     print(
-        "Temperature compensation coefficient:",
-        controller.get_temperature_compensation_coefficient(),
+        "Temperature compensation coefficient: "
+        f"{controller.get_temperature_compensation_coefficient()}mV/°C/Cell"
     )
     print("Battery Voltage Control Register Names:",
           controller.battery_voltage_control_register_names)

--- a/epevermodbus/driver.py
+++ b/epevermodbus/driver.py
@@ -291,6 +291,10 @@ class EpeverChargeController(minimalmodbus.Instrument):
         """Battery capacity in amp hours"""
         return self.retriable_read_register(0x9001, 0, 3)
 
+    def set_battery_capacity(self, capacity: int):
+        """Set Battery capacity in amp hours"""
+        return self.write_register(0x9001, capacity)
+
     def get_temperature_compensation_coefficient(self):
         """Temperature compensation coefficient"""
         return self.retriable_read_register(0x9002, 2, 3)

--- a/epevermodbus/driver.py
+++ b/epevermodbus/driver.py
@@ -293,7 +293,7 @@ class EpeverChargeController(minimalmodbus.Instrument):
 
     def get_temperature_compensation_coefficient(self):
         """Temperature compensation coefficient"""
-        return self.retriable_read_register(0x9002, 0, 3)
+        return self.retriable_read_register(0x9002, 2, 3)
 
     def get_battery_voltage_control_registers(self):
         """Returns all 12 battery voltage control settings"""

--- a/epevermodbus/driver.py
+++ b/epevermodbus/driver.py
@@ -1,3 +1,5 @@
+import datetime
+
 import minimalmodbus
 import serial
 from retrying import retry
@@ -443,3 +445,41 @@ class EpeverChargeController(minimalmodbus.Instrument):
     def get_total_generated_energy(self):
         """Total generated energy"""
         return self.retriable_read_long(0x3312, 4) / 100
+
+    def get_rtc(self):
+        """
+        Reads the RTC.
+        :return: datetime.datetime if successful
+                 None otherwise
+        """
+
+        reg_ms = self.retriable_read_register(0x9013, 0, 3)
+        second = extract_bits(reg_ms, 0, 0b1111_1111)
+        minute = extract_bits(reg_ms, 8, 0b1111_1111)
+
+        reg_hd = self.retriable_read_register(0x9014, 0, 3)
+        hour = extract_bits(reg_hd, 0, 0b1111_1111)
+        day = extract_bits(reg_hd, 8, 0b1111_1111)
+
+        reg_my = self.retriable_read_register(0x9015, 0, 3)
+        month = extract_bits(reg_my, 0, 0b1111_1111)
+        year = extract_bits(reg_my, 8, 0b1111_1111)+2000
+
+        try:
+            dt = datetime.datetime(year, month, day, hour, minute, second)
+        except ValueError:
+            dt = None
+        return dt
+
+    def set_rtc(self, new_time: datetime.datetime):
+        """
+        Set the RTC
+        :param new_time: The new value to set.
+        :return: None
+        """
+
+        reg_ms = new_time.second + (new_time.minute << 8)
+        reg_hd = new_time.hour + (new_time.day << 8)
+        reg_my = new_time.month + ((new_time.year-2000) << 8)
+
+        self.write_registers(0x9013, [reg_ms, reg_hd, reg_my])

--- a/epevermodbus/driver.py
+++ b/epevermodbus/driver.py
@@ -295,6 +295,10 @@ class EpeverChargeController(minimalmodbus.Instrument):
         """Temperature compensation coefficient"""
         return self.retriable_read_register(0x9002, 2, 3)
 
+    def set_temperature_compensation_coefficient(self, coefficient: float):
+        """Set the Temperature compensation coefficient"""
+        return self.write_register(0x9002, coefficient*100)
+
     def get_battery_voltage_control_registers(self):
         """Returns all 12 battery voltage control settings"""
         register_values = self.retriable_read_registers(0x9003, 12, 3)


### PR DESCRIPTION
This patch adds support to read and write the RTC. Documentation has been taken from:
https://www.img4.cz/i4wifi/attach/StoItem/7124/MODBUS-Protocol-v25.pdf

This change has been tested on my EPEVER Tracer2210AN.

This will also close #20 .